### PR TITLE
chore: list project repo in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,14 @@
   ],
   "author": "@JoeScho <joeschofield@live.co.uk>",
   "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/JoeScho/get-ip-range/issues"
+  },
+  "homepage": "https://github.com/JoeScho/get-ip-range#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/JoeScho/get-ip-range.git"
+  },
   "devDependencies": {
     "chai": "^4.1.2",
     "coveralls": "^2.13.3",


### PR DESCRIPTION
That way is linked from the npm page :+1: