### PR TITLE
fix: refactor and fix v4 convertion bug

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 const ip = require('ip');
 const ipAddress = require('ip-address')
-const { cidrv4, cidrv6 } = require('cidr-regex');
+const {cidrv4, cidrv6} = require('cidr-regex');
 
 const errorMessage = new Error('IP supplied is not valid');
 
@@ -53,27 +53,33 @@ const convert = (cidrIp, ip2) => {
       return getRangev6(cidrIp, ip2);
     }
   } else {
-    if (ip1v4.valid) {
-      const subnet = ip.cidrSubnet(cidrIp);
 
-      const firstAddress = subnet.firstAddress;
-      const lastAddress = subnet.lastAddress;
+    const [firstAddress, lastAddress] = isRange(cidrIp) ? cidrIp.split('-') : cidrToRange(cidrIp);
 
-      return getRangev4(firstAddress, lastAddress);
-    }
-
-    if (ip1v6.valid) {
-      const IPv6 = new ipAddress.Address6(cidrIp);
-      return getRangev6(IPv6.startAddress().correctForm(), IPv6.endAddress().correctForm());
-    }
-
-    if (isRange(cidrIp)) {
-      const [ firstAddress, lastAddress ] = cidrIp.split('-');
-      return convert(firstAddress, lastAddress);
-    }
+    return convert(firstAddress, lastAddress);
   }
 
   throw err;
 }
+
+const cidrToRange = (cidr) => {
+
+  const ipv4 = new ipAddress.Address4(cidr);
+  const ipv6 = new ipAddress.Address6(cidr);
+
+  let cidrIP;
+  if (!isCIDR(cidr)) {
+    throw Error(`${cidr} is not CIDR`);
+  } else if (ipv4.valid) {
+    cidrIP = ipv4
+  } else if (ipv6.valid) {
+    cidrIP = ipv6
+  } else {
+    throw Error(`${cidr} is not valid ip`)
+  }
+  const firstAddress = cidrIP.startAddress().correctForm();
+  const lastAddress = cidrIP.endAddress().correctForm();
+  return [firstAddress, lastAddress]
+};
 
 module.exports = convert;

--- a/index.test.js
+++ b/index.test.js
@@ -6,12 +6,14 @@ const { expect } = require('chai');
 const ipConverter = require('./index.js');
 
 const successResponsev4 = [
+  '192.168.1.128',
   '192.168.1.129',
   '192.168.1.130',
   '192.168.1.131',
   '192.168.1.132',
   '192.168.1.133',
   '192.168.1.134',
+  '192.168.1.135'
 ];
 
 const successResponsev6 = [
@@ -251,7 +253,7 @@ describe('convert', function () {
 
     describe('success cases', function () {
       it('should return an array of IP addresses within the specified range', function () {
-        expect(ipConverter('192.168.1.129', '192.168.1.134')).to.deep.equal(successResponsev4);
+        expect(ipConverter('192.168.1.128', '192.168.1.135')).to.deep.equal(successResponsev4);
       });
 
       it('should support IPv6', function () {
@@ -259,7 +261,7 @@ describe('convert', function () {
       });
 
       it('should support hyphenated range in IPv4', function () {
-        expect(ipConverter('192.168.1.129-192.168.1.134')).to.deep.equal(successResponsev4);
+        expect(ipConverter('192.168.1.128-192.168.1.135')).to.deep.equal(successResponsev4);
       });
 
       it('should support hyphenated range in IPv5', function () {

--- a/package-lock.json
+++ b/package-lock.json
@@ -967,9 +967,9 @@
       "dev": true
     },
     "handlebars": {
-      "version": "4.4.5",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.4.5.tgz",
-      "integrity": "sha512-0Ce31oWVB7YidkaTq33ZxEbN+UDxMMgThvCe8ptgQViymL5DPis9uLdTA13MiRPhgvqyxIegugrP97iK3JeBHg==",
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.5.3.tgz",
+      "integrity": "sha512-3yPecJoJHK/4c6aZhSvxOyG4vJKDshV36VHp0iVCDVh7o9w2vwi3NSnL2MMPj3YdduqaBcu7cGbggJQM0br9xA==",
       "dev": true,
       "requires": {
         "neo-async": "^2.6.0",
@@ -2491,9 +2491,9 @@
       "dev": true
     },
     "uglify-js": {
-      "version": "3.6.3",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.3.tgz",
-      "integrity": "sha512-KfQUgOqTkLp2aZxrMbCuKCDGW9slFYu2A23A36Gs7sGzTLcRBDORdOi5E21KWHFIfkY8kzgi/Pr1cXCh0yIp5g==",
+      "version": "3.6.9",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.9.tgz",
+      "integrity": "sha512-pcnnhaoG6RtrvHJ1dFncAe8Od6Nuy30oaJ82ts6//sGSXOP5UjBMEthiProjXmMNHOfd93sqlkztifFMcb+4yw==",
       "dev": true,
       "optional": true,
       "requires": {


### PR DESCRIPTION
expected success result in test data (`successResponsev4`) was wrong. According to https://www.ipaddressguide.com/cidr `192.168.1.134/29` should be converted to 
```
 [
  '192.168.1.128'
  '192.168.1.129',
  '192.168.1.130',
  '192.168.1.131',
  '192.168.1.132',
  '192.168.1.133',
  '192.168.1.134',
  '192.168.1.135'
];
```
